### PR TITLE
include node_modules in the artifact

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
         "babel-preset-es2017": "^6.24.1"
     },
     "scripts": {
-        "build": "npm run build:init && npm run build:js",
-        "build:init": "rm -rf dist && mkdir dist",
         "build": "npm run build:init && npm run build:js && npm run build:install",
+        "build:init": "rm -rf dist && mkdir dist",
+        "build:js": "cd src && babel *.js **/*.js -d ../dist",
         "build:install": "cp package.json dist/ && cd dist && npm install --production",
         "package": "npm run build && npm run package:pack",
         "package:pack": "rm -f artifact.zip && cd dist/ && zip -r ../artifact.zip *"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "scripts": {
         "build": "npm run build:init && npm run build:js",
         "build:init": "rm -rf dist && mkdir dist",
-        "build:js": "cd src && babel *.js **/*.js -d ../dist",
+        "build": "npm run build:init && npm run build:js && npm run build:install",
         "build:install": "cp package.json dist/ && cd dist && npm install --production",
         "package": "npm run build && npm run package:pack",
         "package:pack": "rm -f artifact.zip && cd dist/ && zip -r ../artifact.zip *"


### PR DESCRIPTION
currently node_modules is not included, so any third party module required can't be executed by the lambda