### PR TITLE
transpile third level sub-directories

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Irvin Lim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
         "babel-preset-es2017": "^6.24.1"
     },
     "scripts": {
-        "build": "npm run build:init && npm run build:js",
-        "build:init": "rm -rf dist && mkdir dist",
         "build": "npm run build:init && npm run build:js && npm run build:install",
+        "build:init": "rm -rf dist && mkdir dist",
+        "build:js": "cd src && babel *.js **/*.js -d ../dist",
         "build:install": "cp package.json dist/ && cd dist && npm install --production",
         "package": "npm run build && npm run package:pack",
         "package:pack": "rm -f artifact.zip && cd dist/ && zip -r ../artifact.zip *"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "scripts": {
         "build": "npm run build:init && npm run build:js",
         "build:init": "rm -rf dist && mkdir dist",
-        "build:js": "cd src && babel *.js **/*.js -d ../dist",
+        "build": "npm run build:init && npm run build:js && npm run build:install",
         "build:install": "cp package.json dist/ && cd dist && npm install --production",
         "package": "npm run build && npm run package:pack",
         "package:pack": "rm -f artifact.zip && cd dist/ && zip -r ../artifact.zip *"


### PR DESCRIPTION
I'm not sure why, but `**/*.js` was not enough for me to transpile third level sub-directories. I had to add `**/**/*.js` for this to work.