### PR TITLE
Fix docker-lambda image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: node_js
 node_js:
 - "6.10.0"
 before_install:
-- docker pull lambci/lambda
+- docker pull lambci/lambda:nodejs6.10
 script:
 - npm run spec
 - npm run test

--- a/spec/functional/es2016-array-includes.test.js
+++ b/spec/functional/es2016-array-includes.test.js
@@ -9,15 +9,16 @@ const path = filename => `es2016-array-includes/${filename}.js`;
 
 /**
  * @see http://node.green/#ES2016-features-Array-prototype-includes-Array-prototype-includes
- * @ignore babel-plugin-array-includes is not complete
+ * @ignore babel-plugin-array-includes is not fully spec-compliant (see https://github.com/tc39/Array.prototype.includes)
  */
 it('Array.prototype.includes');
 
 /**
  * @see http://node.green/#ES2016-features-Array-prototype-includes-Array-prototype-includes-is-generic
- * @ignore babel-plugin-array-includes is not complete
  */
-it('Array.prototype.includes is generic');
+it('Array.prototype.includes is generic', function() {
+    expect(runTest(path('generic'))).toEqual(true);
+});
 
 /**
  * @see http://node.green/#ES2016-features-Array-prototype-includes--TypedArray--prototype-includes

--- a/spec/functional/utils/runner.js
+++ b/spec/functional/utils/runner.js
@@ -26,6 +26,8 @@ function runTest(filename) {
     try {
         // Run the Lambda in Docker.
         result = dockerLambda({
+            // Use the Node.js 6.10.0 image.
+            dockerImage: 'lambci/lambda:nodejs6.10',
             // Bind the parent directory as a volume to /var/task.
             taskDir: path.join(__dirname, '../'),
             // Specify the Lambda handler.

--- a/test/util/runner.js
+++ b/test/util/runner.js
@@ -13,6 +13,8 @@ function run(event) {
     try {
         // Run the Lambda in Docker.
         result = dockerLambda({
+            // Use the Node.js 6.10.0 image.
+            dockerImage: 'lambci/lambda:nodejs6.10',
             // Bind the build directory as a volume to /var/task.
             taskDir: path.join(__dirname, '../dist'),
             // Pass an event to the Lambda function.


### PR DESCRIPTION
Previously it was using the default Node.js 4.3 tag from Docker hub. Re-enabled one additional spec test case.