### PR TITLE
Fix Object.values/Object.entries 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -19,6 +19,7 @@
                 "commentEnd": "\n "
             }
         ],
+        "transform-es2015-modules-commonjs",
         "transform-es2017-object-entries",
         "transform-object-rest-spread",
         "transform-es2015-destructuring",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-array-includes": "^2.0.3",
         "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
         "babel-plugin-transform-es2017-object-entries": "0.0.4",
         "babel-plugin-transform-object-rest-spread": "^6.26.0",
         "babel-preset-env": "^1.6.1",

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,8 @@ export default (event, context) => {
             return restApiExample(event.data, context);
         case 'aws-sdk-example':
             return awsSdkExample(event.data, context);
+        case 'integration-test-example':
+            return integrationTestExample(event.data, context);
     }
 };
 
@@ -43,6 +45,36 @@ const restApiExample = async (data, context) => {
 const awsSdkExample = async (data, context) => {
     const EC2 = new AWS.EC2();
 
+    // return [
+    //     AWS.config.accessKeyId,
+    //     process.env.AWS_ACCESS_KEY_ID,
+    //     AWS.config.secretAccessKey,
+    //     process.env.AWS_SECRET_ACCESS_KEY,
+    // ];
+
     // Sample EC2 call.
     return await EC2.describeInstances().promise();
+};
+
+// Sample function used for integration testing against each ES2016/7 feature
+// purportedly supported by the boilerplate.
+const integrationTestExample = (data, context) => {
+    let value;
+
+    switch (data.function) {
+        case 'Object.values':
+            return Object.values(data.value);
+        case 'Object.entries':
+            return Object.entries(data.value);
+        case 'Array.prototype.includes':
+            return data.value.includes(data.value2);
+        case 'Exponentiation':
+            return data.value ** data.value2;
+        case 'Object spread properties':
+            const { value } = data;
+            return value;
+        case 'Object rest properties':
+            const { child, ...rest } = data.value;
+            return rest;
+    }
 };

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,0 +1,117 @@
+/**
+ * Runs integration tests for each ES2017/ES2016 feature that
+ * is purportedly supported by the boilerplate.
+ * The difference between this and the specification tests is
+ * that while specification tests ensure that the Babel config
+ * is correct, integration tests ensure that the rest of the
+ * Javascript boilerplate code for the Lambda is working as expected
+ * and does not crash/fail to transpile.
+ *
+ * NOTE: You should remove this in your actual production code.
+ * This is only for testing the boilerplate.
+ */
+
+import run from './util/runner';
+
+it('should call Object.entries correctly', function() {
+    const event = {
+        type: 'integration-test-example',
+        data: {
+            function: 'Object.entries',
+            value: {
+                hello: 'world',
+                number: 100,
+                isTrue: true,
+            },
+        },
+    };
+
+    const result = run(event);
+
+    expect(result).toEqual([
+        ['hello', 'world'],
+        ['number', 100],
+        ['isTrue', true],
+    ]);
+});
+
+it('should call Object.values correctly', function() {
+    const event = {
+        type: 'integration-test-example',
+        data: {
+            function: 'Object.values',
+            value: {
+                hello: 'world',
+                number: 100,
+                isTrue: true,
+            },
+        },
+    };
+
+    const result = run(event);
+
+    expect(result).toEqual(['world', 100, true]);
+});
+
+it('should call Array.prototype.includes correctly', function() {
+    const event = {
+        type: 'integration-test-example',
+        data: {
+            function: 'Array.prototype.includes',
+            value: [1, 5, 70, 3, 54],
+            value2: 3,
+        },
+    };
+
+    const result = run(event);
+
+    expect(result).toEqual(true);
+});
+
+it('should call Exponentiation correctly', function() {
+    const event = {
+        type: 'integration-test-example',
+        data: {
+            function: 'Exponentiation',
+            value: 2,
+            value2: 10,
+        },
+    };
+
+    const result = run(event);
+
+    expect(result).toEqual(1024);
+});
+
+it('should call Object spread properties correctly', function() {
+    const event = {
+        type: 'integration-test-example',
+        data: {
+            function: 'Object spread properties',
+            value: {
+                hello: 'world',
+            },
+        },
+    };
+
+    const result = run(event);
+
+    expect(result).toEqual({ hello: 'world' });
+});
+
+it('should call Object rest properties correctly', function() {
+    const event = {
+        type: 'integration-test-example',
+        data: {
+            function: 'Object rest properties',
+            value: {
+                child: 'first',
+                otherChild: 'second',
+            },
+        },
+    };
+
+    const result = run(event);
+
+    expect(result).toEqual({ otherChild: 'second' });
+});


### PR DESCRIPTION
Fixes #20.

Also added integration tests (for the boilerplate) which test that the boilerplate is able to utilise each of the ES2016/7 features that we purportedly support.

## Changes
- Add integration tests to ensure all ES2016/7 features are working correctly
- Add missing Babel plugin transform-es2015-modules-commonjs
  - Missing transform caused  transform-es2017-object-entries to fail with ESM imports