### PR TITLE
Capture system logs from docker-lambda

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1161,6 +1161,17 @@
                 "has-ansi": "2.0.0",
                 "strip-ansi": "3.0.1",
                 "supports-color": "2.0.0"
+            },
+            "dependencies": {
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                }
             }
         },
         "chokidar": {
@@ -5195,12 +5206,20 @@
             "dev": true
         },
         "strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "3.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                }
             }
         },
         "strip-bom": {
@@ -5574,6 +5593,15 @@
                         "is-fullwidth-code-point": "1.0.0",
                         "strip-ansi": "3.0.1"
                     }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
                 }
             }
         },
@@ -5671,6 +5699,15 @@
                                 "code-point-at": "1.1.0",
                                 "is-fullwidth-code-point": "1.0.0",
                                 "strip-ansi": "3.0.1"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "2.1.1"
                             }
                         }
                     }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
         "dotenv": "^5.0.0",
         "fs-extra": "^5.0.0",
         "jest": "^22.0.0",
-        "rimraf": "^2.6.2"
+        "rimraf": "^2.6.2",
+        "strip-ansi": "^4.0.0"
     },
     "jest": {
         "testEnvironment": "node",
-        "testRegex": "\\.test\\.js$"
+        "testRegex": "\\.test\\.js$",
+        "noStackTrace": true
     },
     "scripts": {
         "build": "npm run build:init && npm run build:js && npm run build:install",

--- a/test/util/logs.js
+++ b/test/util/logs.js
@@ -1,0 +1,81 @@
+import stripAnsi from 'strip-ansi';
+
+// Define which system logs to strip out when parsing stderr from docker-lambda.
+const BLACKLISTED_GREPS = [
+    /^START RequestId: /,
+    /^END RequestId: /,
+    /^REPORT RequestId: /,
+];
+
+/**
+ * Returns an array of lines that were logged using console.log()
+ * within an invocation of AWS Lambda, extracted from the system log.
+ *
+ * @param {string} stderr Raw log from AWS Lambda.
+ * @returns {array} Array of lines that were logged to the console.
+ */
+function getSysLogLines(stderr) {
+    return stderr
+        .trim()
+        .split('\n')
+        .map(stripAnsi)
+        .filter(line => BLACKLISTED_GREPS.every(grep => !grep.test(line)))
+        .map(removeSysLogHeaders);
+}
+
+/**
+ * Strips headers from a line of raw system logs from AWS Lambda.
+ * This removes the timestamp and the request ID, which are delimited
+ * by tabs.
+ *
+ * @param {string} logLine Raw stderr system log line.
+ * @returns {string} Log line without timestamps and request IDs.
+ */
+function removeSysLogHeaders(logLine) {
+    return logLine
+        .split('\t')
+        .slice(2)
+        .join('\t');
+}
+
+/**
+ * Formats a list of console.log() message to be displayed in
+ * the test runner.
+ *
+ * @param {string[]} messages Messages to be displayed.
+ * @returns {string} Formatted console messages.
+ */
+function formatLogForConsole(message) {
+    const lines = [
+        '\u001b[1;33mCaptured logs while executing Lambda function:\u001b[0m',
+        message,
+    ];
+
+    return lines.join('\n\n');
+}
+
+/**
+ * Formats an error message to be displayed in the test runner
+ * when the Lambda invocation encounters an error.
+ *
+ * @param {string} message Error message to be displayed.
+ * @param {string} stderr AWS system log redirected from stderr.
+ * @returns {string} Formatted error message.
+ */
+function formatLogForError(message, stderr) {
+    const lines = [
+        '\u001b[1;31mError while executing Lambda function:\u001b[0m',
+        message + '\n',
+        '\u001b[1;33mDisplaying AWS Lambda system log:\u001b[0m',
+        stripAnsi(stderr),
+    ];
+
+    return lines.join('\n');
+}
+
+module.exports = {
+    getSysLogLines,
+    removeSysLogHeaders,
+    formatLogForConsole,
+    formatLogForError,
+};

--- a/test/util/runner.js
+++ b/test/util/runner.js
@@ -30,8 +30,9 @@ function run(event) {
         });
     } catch (err) {
         // Throw errors back to test runner.
-        console.error('Error while executing Lambda function: ', err.message);
-        throw err;
+        const { errorMessage } = JSON.parse(err.stdout);
+        const error = new Error(errorMessage);
+        throw error;
     }
 
     return result;

--- a/test/util/runner.js
+++ b/test/util/runner.js
@@ -1,3 +1,10 @@
+import {
+    formatLogForConsole,
+    formatLogForError,
+    getSysLogLines,
+    removeSysLogHeaders,
+} from './logs';
+
 import dockerLambda from 'docker-lambda';
 import dotenv from 'dotenv';
 import path from 'path';
@@ -9,33 +16,47 @@ function run(event) {
     // Run the Lambda function.
     let result;
 
-    try {
-        // Run the Lambda in Docker.
-        result = dockerLambda({
-            // Use the Node.js 6.10.0 image.
-            dockerImage: 'lambci/lambda:nodejs6.10',
-            // Bind the build directory as a volume to /var/task.
-            taskDir: path.join(__dirname, '../dist'),
-            // Pass an event to the Lambda function.
-            event,
-            // Pass AWS credentials from environment.
-            // NOTE: Jest needs the environment variable values explicitly,
-            // see https://github.com/facebook/jest/issues/5362.
-            dockerArgs: [
-                '-e',
-                `AWS_ACCESS_KEY_ID=${process.env.AWS_ACCESS_KEY_ID}`,
-                '-e',
-                `AWS_SECRET_ACCESS_KEY=${process.env.AWS_SECRET_ACCESS_KEY}`,
-            ],
-        });
-    } catch (err) {
+    // Run the Lambda in Docker.
+    result = dockerLambda({
+        // Use the Node.js 6.10.0 image.
+        dockerImage: 'lambci/lambda:nodejs6.10',
+        // Bind the build directory as a volume to /var/task.
+        taskDir: path.join(__dirname, '../dist'),
+        // Pass an event to the Lambda function.
+        event,
+        // Pass AWS credentials from environment.
+        // NOTE: Jest needs the environment variable values explicitly,
+        // see https://github.com/facebook/jest/issues/5362.
+        dockerArgs: [
+            '-e',
+            `AWS_ACCESS_KEY_ID=${process.env.AWS_ACCESS_KEY_ID}`,
+            '-e',
+            `AWS_SECRET_ACCESS_KEY=${process.env.AWS_SECRET_ACCESS_KEY}`,
+        ],
+        // Capture both stderr and stdout, instead of catching Errors.
+        returnSpawnResult: true,
+    });
+
+    // Catch Lambda errors, based on spawn status codes/errors.
+    if (result.error || result.status !== 0) {
         // Throw errors back to test runner.
-        const { errorMessage } = JSON.parse(err.stdout);
-        const error = new Error(errorMessage);
-        throw error;
+        const { errorMessage } = JSON.parse(result.stdout);
+
+        // Format error message to be displayed in test runner.
+        const combinedErrorMsg = formatLogForError(errorMessage, result.stderr);
+
+        throw new Error(combinedErrorMsg);
     }
 
-    return result;
+    // Capture any console.log occurrences by inspecting the syslog.
+    const logs = getSysLogLines(result.stderr);
+
+    // Display all messages in a single block in the test runner.
+    if (logs.length) {
+        console.log(formatLogForConsole(logs));
+    }
+
+    return JSON.parse(result.stdout);
 }
 
 module.exports = run;

--- a/test/util/runner.js
+++ b/test/util/runner.js
@@ -13,17 +13,20 @@ import path from 'path';
 dotenv.config();
 
 function run(event) {
-    // Run the Lambda function.
-    let result;
-
     // Run the Lambda in Docker.
-    result = dockerLambda({
+    const result = dockerLambda({
         // Use the Node.js 6.10.0 image.
         dockerImage: 'lambci/lambda:nodejs6.10',
+
         // Bind the build directory as a volume to /var/task.
         taskDir: path.join(__dirname, '../dist'),
+
+        // Capture both stderr and stdout, instead of catching Errors.
+        returnSpawnResult: true,
+
         // Pass an event to the Lambda function.
         event,
+
         // Pass AWS credentials from environment.
         // NOTE: Jest needs the environment variable values explicitly,
         // see https://github.com/facebook/jest/issues/5362.
@@ -33,8 +36,6 @@ function run(event) {
             '-e',
             `AWS_SECRET_ACCESS_KEY=${process.env.AWS_SECRET_ACCESS_KEY}`,
         ],
-        // Capture both stderr and stdout, instead of catching Errors.
-        returnSpawnResult: true,
     });
 
     // Catch Lambda errors, based on spawn status codes/errors.

--- a/test/util/runner.js
+++ b/test/util/runner.js
@@ -1,9 +1,4 @@
-import {
-    formatLogForConsole,
-    formatLogForError,
-    getSysLogLines,
-    removeSysLogHeaders,
-} from './logs';
+import { formatLogForConsole, formatLogForError, getSysLogLines } from './logs';
 
 import dockerLambda from 'docker-lambda';
 import dotenv from 'dotenv';


### PR DESCRIPTION
Fixes #24.

By using the `returnSpawnResult` flag from docker-lambda, we can capture the output of the AWS Lambda system log, which captures any `console.log()` calls within the Lambda source code. Thus, the system log is parsed out and displayed within the test runner in a friendly format.