### PR TITLE
Use GH_TOKEN in example GitHub API request

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -37,6 +37,11 @@ const restApiExample = async (data, context) => {
         headers: { 'User-Agent': 'AWS Lambda' },
     };
 
+    // Use GitHub API token to bypass rate limits.
+    if (process.env.GH_TOKEN) {
+        options.headers.Authorization = `token ${process.env.GH_TOKEN}`;
+    }
+
     // Await the Promise.
     return await request(options);
 };

--- a/test/util/runner.js
+++ b/test/util/runner.js
@@ -30,6 +30,8 @@ function run(event) {
             `AWS_ACCESS_KEY_ID=${process.env.AWS_ACCESS_KEY_ID}`,
             '-e',
             `AWS_SECRET_ACCESS_KEY=${process.env.AWS_SECRET_ACCESS_KEY}`,
+            '-e',
+            `GH_TOKEN=${process.env.GH_TOKEN}`,
         ],
     });
 


### PR DESCRIPTION
Allow `GH_TOKEN` environment variable to be used in example request, which passes tests on Travis in order to bypass the shared, unauthorized [rate limits](https://developer.github.com/v3/#rate-limiting) from GitHub API.